### PR TITLE
Ensure loading score after brain is initialized

### DIFF
--- a/scripts/scorekeeper.coffee
+++ b/scripts/scorekeeper.coffee
@@ -19,16 +19,25 @@ class Scorekeeper
   _prefix = "scorekeeper"
 
   constructor: (@robot) ->
+    @_loaded = false
     @_scores = {}
-    @_load()
+    @robot.brain.on 'loaded', =>
+      @_load()
+      @_loaded = true
 
   increment: (user, func) ->
+    unless @_loaded
+      setTimeout((=> @increment(user,func)), 200)
+      return
     @_scores[user] = @_scores[user] or 0
     @_scores[user]++
     @_save()
     @score user, func
 
   decrement: (user, func) ->
+    unless @_loaded
+      setTimeout((=> @decrement(user,func)), 200)
+      return
     @_scores[user] = @_scores[user] or 0
     @_scores[user]--
     @_save()


### PR DESCRIPTION
Hi, thanks for the great plugin!

BTW I found that the score is unexpectedly loaded and set to `{}`
before (especially redis) brain is initialized, in some cases.
So I have been encountering the trouble that the robot forgets all of score every time it is restarted!

So, I fixed!
