### PR TITLE
Improvement: Multiple detection and Remove an user

### DIFF
--- a/scripts/scorekeeper.coffee
+++ b/scripts/scorekeeper.coffee
@@ -82,15 +82,16 @@ module.exports = (robot) ->
       user = user.replace(mention_matcher, "")
     user
 
-  robot.hear /(.+)\+\+$/, (msg) ->
-    user = userName(msg.match[1])
-    scorekeeper.increment user, (error, result) ->
-      msg.send "incremented #{user} (#{result} pt)"
-
-  robot.hear /(.+)\-\-$/, (msg) ->
-    user = userName(msg.match[1])
-    scorekeeper.decrement user, (error, result) ->
-      msg.send "decremented #{user} (#{result} pt)"
+  robot.hear /\w+(?:(?:\+\+)|(?:\-\-))/g, (msg) ->
+    for str in msg.match
+      user = userName(str.slice(0, -2))
+      direction = str.slice(-2)
+      if direction == "++"
+        scorekeeper.increment user, (error, result) ->
+          msg.send "incremented #{user} (#{result} pt)"
+      else if direction == "--"
+        scorekeeper.decrement user, (error, result) ->
+          msg.send "decremented #{user} (#{result} pt)"
 
   robot.respond /scorekeeper$|show(?: me)?(?: the)? (?:scorekeeper|scoreboard)$/i, (msg) ->
     scorekeeper.rank (error, result) ->

--- a/scripts/scorekeeper.coffee
+++ b/scripts/scorekeeper.coffee
@@ -46,6 +46,12 @@ class Scorekeeper
   score: (user, func) ->
     func false, @_scores[user] or 0
 
+  remove: (user, func) ->
+    score = @_scores[user]
+    delete @_scores[user]
+    @_save()
+    func false, score
+
   rank: (func)->
     ranking = (for name, score of @_scores
       [name, score]
@@ -91,6 +97,11 @@ module.exports = (robot) ->
       msg.send (for rank, name of result
         "#{parseInt(rank) + 1} : #{name}"
       ).join("\n")
+
+  robot.respond /scorekeeper remove (.+)$/i, (msg) ->
+    user = userName(msg.match[1])
+    scorekeeper.remove user, (error, result) ->
+      msg.send "#{user} has been removed. (#{result} pt)"
 
   robot.respond /scorekeeper (.+)$|what(?:'s| is)(?: the)? score of (.+)\??$/i, (msg) ->
     user = userName(msg.match[1] || msg.match[2])


### PR DESCRIPTION
## Multiple detection

Now we can increment multiple users at one line!

For example, this command will increment taro and hanako:
`taro++, hanako++` ,

This will add 3 points to taro:
 `taro++ taro++ taro++`

And, this is just a joke:
`taro-- taro++`
## Remove an user

When you mistyped name, now you can remove it.

```
tarp++
hubot scorekeeper remove tarp
```
